### PR TITLE
list_tables: use Table returned by quick, not str, fixes #7

### DIFF
--- a/mastcasjobs.py
+++ b/mastcasjobs.py
@@ -115,7 +115,7 @@ class MastCasJobs(CasJobs):
         res = self.quick(q, context=context, task_name='listtables', system=True)
         # the first line is a header and the last is always empty
         # also, the table names have " as the first and last characters
-        return [l[1:-1]for l in res.split('\n')[1:-1]]
+        return list(res["TABLE_NAMES"])
 
     def drop_table_if_exists(self, table):
         """


### PR DESCRIPTION
```quick``` returns an ```satrapy.Table``` and not a ```str```.
Now ```list_tables``` uses that Table.