### PR TITLE
Add upload for astropy table to MyDB

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mastcasjobs
-version = 0.0.5
+version = 0.0.6
 description = An interface to MAST CasJobs.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Modified the `upload_table()` method in the `MastCasJobs` class to allow an `astropy` table as the data argument. This allows some augmented capabilities:

- Break large tables that exceed the casjobs upload size limit into chunks.
- Replace embedded blanks in the column values (which break the upload due to a bug) with underscores.

Bumped the version from 0.0.5 to 0.0.6.